### PR TITLE
S font

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+/* @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@700&display=swap"); */
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -7,6 +9,7 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    /* font-family: "Noto Sans KR", sans-serif; */
   }
 }
 
@@ -19,7 +22,6 @@ body {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${notoSansKr.className}`}>{children}</body>
+      {/* <body>{children}</body> */}
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,11 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import { Noto_Sans_KR } from "next/font/google";
 import "./globals.css";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
+const notoSansKr = Noto_Sans_KR({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-noto-sans",
 });
 
 export const metadata: Metadata = {
@@ -25,9 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
-      </body>
+      <body className={`${notoSansKr.className}`}>{children}</body>
     </html>
   );
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -13,7 +13,6 @@
   min-height: 100svh;
   padding: 80px;
   gap: 64px;
-  font-family: var(--font-geist-sans);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,7 +34,6 @@
 }
 
 .main ol {
-  font-family: var(--font-geist-mono);
   padding-left: 0;
   margin: 0;
   font-size: 14px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function Home() {
           <li>
             Get started by editing <code>src/app/page.tsx</code>.
           </li>
-          <li>Save and see your changes instantly.</li>
+          <li>한국어</li>
         </ol>
 
         <div className={styles.ctas}>


### PR DESCRIPTION
```ts
import { NotoSans_KR } from 'next/font/google';
```

- 구글 폰트를 사용하면 배포된 프로젝트에 포함되기 때문에 따로 구글에 요청이 가지 않는다고 합니다.
- 참고: https://nextjs.org/docs/app/building-your-application/optimizing/fonts#google-fonts
- 구글 폰트는 자동으로 서브셋 폰트이 설정되어있다고 합니다.
- 참고: https://nextjs.org/docs/app/building-your-application/optimizing/fonts#specifying-a-subset
- 서브셋에 대해 알아보니, 한국어 폰트 경우 '갞' 처럼 사용하지 않는 글자들이 있는데 이런 경우를 제외하고 실제로 사용되는 글자들만 포함하는 것을 폰트의 하위 집합으로 보고 "서브셋 폰트"라고 하는걸 알았습니다.
- 실제 Noto Sans KR 폰트 파일의 용량은 MB 단위이지만 구글 폰트에서 제공하는 것은 KB 단위로 작은 것을 발견했습니다.

## subsets 사용
 ```ts
const inter = Inter({ subsets: ['latin'] })
```
- 라틴 말고 다른 서브셋들을 추가하면 해당 서브셋 폰트 파일들을 따로 다운로드 받는 것을 발견했습니다.
- 서브셋을 여러 가지 지정할수록 다운받는 서브셋 폰트 파일들도 늘어납니다.
- 만약 `subsets: []` 빈배열이라면 `['latin']` 값을 기본 사용합니다.

## weight 사용
```ts
const inter = Inter({ subsets: ['latin'], weight: ['400', '700'] })
```
- weight 배열 요소 개수가 적을수록 폰트 파일 용량이 적은 것을 발견했습니다.

## preload 기본 적용
```ts
const inter = Inter({ subsets: ['latin'], weight: ['400', '700'], preload: false })
```
- preload 값은 true 가 기본 적용되어 있습니다.
- preload 값이 true 인 경우, subsets 을 설정해줘야합니다.

## variable 사용
```ts
const inter = Inter({ subsets: ['latin'], weight: ['400', '700'], variable: '--my-font'});
```
- css 파일에서 해당 폰트를 사용가능하게 합니다.
- 예시 코드
```css
.dark {
  font-family: var(--my-font);
}
.light {
  font-family: var(--your-font);
}
```